### PR TITLE
replaced vm concatenated name with locals - Nate

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -2,6 +2,10 @@
 # This module allows the creation of n Linux VM with 1 NIC #
 ############################################################
 
+locals {
+  vm_name_prefix = "${var.VmEnv}lin${format("%04d", var.VmNumber)}l"
+}
+
 # Create Password for vm
 resource "random_password" "TerraVM-pass" {
   length = 16
@@ -11,7 +15,7 @@ resource "random_password" "TerraVM-pass" {
 
 # save password in keyvault secret
 resource "azurerm_key_vault_secret" "TerraVM-secret" {
-  name         = "${var.VmEnv}lin${format("%04d", var.VmNumber)}l-${var.VmAdminName}"
+  name         = "${locals.vm_name_prefix}-${var.VmAdminName}"
   value        = random_password.TerraVM-pass.result
   key_vault_id = var.KvId
   tags = {
@@ -31,7 +35,7 @@ resource "azurerm_key_vault_secret" "TerraVM-secret" {
 
 # Create storage account for each VM Diag
 resource azurerm_storage_account "TerraVM-diag" {
-  name  =  "${var.VmEnv}lin${format("%04d", var.VmNumber)}ldiag"
+  name  =  "${locals.vm_name_prefix}diag"
   resource_group_name = var.RgName
   location = var.RgLocation
   account_tier = "Standard"
@@ -52,7 +56,7 @@ resource azurerm_storage_account "TerraVM-diag" {
 
 # Create 1 NIC pour each VM
 resource "azurerm_network_interface" "TerraVM-nic0" {
-  name                = "${var.VmEnv}lin${format("%04d", var.VmNumber)}l-nic0"
+  name                = "${locals.vm_name_prefix}-nic0"
   resource_group_name = var.RgName
   location            = var.RgLocation
   #dns_servers         = var.Dns
@@ -66,8 +70,8 @@ resource "azurerm_network_interface" "TerraVM-nic0" {
 
 # Create n VM
 resource "azurerm_linux_virtual_machine" "TerraVM" {
-  name                = "${var.VmEnv}lin${format("%04d", var.VmNumber)}l"
-  computer_name       = "${var.VmEnv}lin${format("%04d", var.VmNumber)}l"
+  name                = "${locals.vm_name_prefix}"
+  computer_name       = "${locals.vm_name_prefix}"
   resource_group_name = var.RgName
   location            = var.RgLocation
   size                = var.VmSize
@@ -83,7 +87,7 @@ resource "azurerm_linux_virtual_machine" "TerraVM" {
   }
 
   os_disk {
-    name                 = "${var.VmEnv}lin${format("%04d", var.VmNumber)}l-OsDisk"
+    name                 = "${locals.vm_name_prefix}-OsDisk"
     caching              = "ReadWrite"
     storage_account_type = var.VmStorageTier#"Standard_LRS"
   }


### PR DESCRIPTION
created folowing locals

locals {
  vm_name_prefix = "${var.VmEnv}lin${format("%04d", var.VmNumber)}l"
}

use locals.vm_name_prefix everywhere instead of ${var.VmEnv}lin${format("%04d", var.VmNumber)}l to keep code dry.
